### PR TITLE
Use `__int128` only when `__SIZEOF_INT128__ == 16`

### DIFF
--- a/jtckdint.h
+++ b/jtckdint.h
@@ -69,9 +69,7 @@
 
 #define __STDC_VERSION_STDCKDINT_H__ 202311L
 
-#if ((defined(__llvm__) ||                                              \
-      (defined(__GNUC__) && __GNUC__ * 100 + __GNUC_MINOR__ >= 406)) && \
-     !defined(__STRICT_ANSI__) && defined(__SIZEOF_INT128__))
+#ifdef __SIZEOF_INT128__
 #define __ckd_have_int128
 #define __ckd_intmax __int128
 #elif ((defined(__cplusplus) && __cplusplus >= 201103L) ||              \

--- a/jtckdint.h
+++ b/jtckdint.h
@@ -71,7 +71,7 @@
 
 #if ((defined(__llvm__) ||                                              \
       (defined(__GNUC__) && __GNUC__ * 100 + __GNUC_MINOR__ >= 406)) && \
-     !defined(__STRICT_ANSI__)) && __SIZEOF_INT128__ == 16
+     !defined(__STRICT_ANSI__) && defined(__SIZEOF_INT128__))
 #define __ckd_have_int128
 #define __ckd_intmax __int128
 #elif ((defined(__cplusplus) && __cplusplus >= 201103L) ||              \

--- a/jtckdint.h
+++ b/jtckdint.h
@@ -69,7 +69,7 @@
 
 #define __STDC_VERSION_STDCKDINT_H__ 202311L
 
-#ifdef __SIZEOF_INT128__
+#if (!defined(__STRICT_ANSI__) && defined(__SIZEOF_INT128__))
 #define __ckd_have_int128
 #define __ckd_intmax __int128
 #elif ((defined(__cplusplus) && __cplusplus >= 201103L) ||              \

--- a/jtckdint.h
+++ b/jtckdint.h
@@ -69,10 +69,9 @@
 
 #define __STDC_VERSION_STDCKDINT_H__ 202311L
 
-#if defined(__SIZEOF_LONG__) && __SIZEOF_LONG__ >= 8 && \
-    ((defined(__llvm__) ||                                              \
+#if ((defined(__llvm__) ||                                              \
       (defined(__GNUC__) && __GNUC__ * 100 + __GNUC_MINOR__ >= 406)) && \
-     !defined(__STRICT_ANSI__))
+     !defined(__STRICT_ANSI__)) && __SIZEOF_INT128__ == 16
 #define __ckd_have_int128
 #define __ckd_intmax __int128
 #elif ((defined(__cplusplus) && __cplusplus >= 201103L) ||              \


### PR DESCRIPTION
"__int128" may only be used when targetting a 64-bit platform. Previously, this type would be used as the longest integer type even when that condition is not met.

If the type is still preset for compiler that does not define this macro, it can be freely set by the user.

This change was tested with i686 GCC and x86 MSVC on Windows.

This will undo the changes from 6764e17814750839dec1f4cc41f7be0ddcae6449 as I think this more accurately satisfies the requirements to use `__int128` across platforms.